### PR TITLE
Fix menu links for algs with spaces in name

### DIFF
--- a/server/src/php/menu.php
+++ b/server/src/php/menu.php
@@ -151,8 +151,8 @@
             echo "</button>";
             echo "<div class='expandableChild'>";
                 foreach ($group as $alg) {
-                    $alg = str_replace("-", " ", $alg);
-                    echo "<a href='/algorithms/$alg' class='menuLink'>$alg</a>";
+                    $algName = str_replace("-", " ", $alg);
+                    echo "<a href='/algorithms/$algName' class='menuLink'>$alg</a>";
                 }
             echo "</div>";
         echo "</div>";

--- a/server/src/php/menu.php
+++ b/server/src/php/menu.php
@@ -152,7 +152,7 @@
             echo "<div class='expandableChild'>";
                 foreach ($group as $alg) {
                     $algName = str_replace("-", " ", $alg);
-                    echo "<a href='/algorithms/$algName' class='menuLink'>$alg</a>";
+                    echo "<a href='/algorithms/$alg' class='menuLink'>$algName</a>";
                 }
             echo "</div>";
         echo "</div>";


### PR DESCRIPTION
Clicking alg links with spaces in the name go to a 404.
e.g. https://cubingapp.com/algorithms/OH%20CMLL
instead of https://cubingapp.com/algorithms/OH-CMLL/
This change just splits out the display name from the link location.