### PR TITLE
fix: correct "mamny" typo on 4x4 PLL parity page

### DIFF
--- a/alg-codegen/algs/4x4-PLL-Parity.json
+++ b/alg-codegen/algs/4x4-PLL-Parity.json
@@ -2,7 +2,7 @@
     "puzzle": "4x4",
     "diagramType": "2D",
     "texts": [
-        "When you are solving a 4x4, PLL parity can significantly slow down a solve. Luckily, there are some tricks you can use to minimize the damage without learning too mamny new algorithms.",
+        "When you are solving a 4x4, PLL parity can significantly slow down a solve. Luckily, there are some tricks you can use to minimize the damage without learning too many new algorithms.",
         "Some algorithms in this set are similar to PLL algorithms you already know, except there is a parity algorithm mixed in. By doing the parity algorithm strategically, you can turn a slow PLL into a fast PLL."
     ],
     "cases": {

--- a/server/src/algorithms/4x4-PLL-Parity/index.php
+++ b/server/src/algorithms/4x4-PLL-Parity/index.php
@@ -21,7 +21,7 @@ include_once "../colorScheme.php";
     <main>
         <div style="width: 100%; max-width: 700px; height: 100%;">
             <h1>4x4 PLL Parity Algorithms</h1>
-            <p class="bodytext">When you are solving a 4x4, PLL parity can significantly slow down a solve. Luckily, there are some tricks you can use to minimize the damage without learning too mamny new algorithms.</p>
+            <p class="bodytext">When you are solving a 4x4, PLL parity can significantly slow down a solve. Luckily, there are some tricks you can use to minimize the damage without learning too many new algorithms.</p>
 			<p class="bodytext">Some algorithms in this set are similar to PLL algorithms you already know, except there is a parity algorithm mixed in. By doing the parity algorithm strategically, you can turn a slow PLL into a fast PLL.</p>
             
             <?php

--- a/tanstack/src/routes/algorithms/algs/4x4-PLL-Parity.json
+++ b/tanstack/src/routes/algorithms/algs/4x4-PLL-Parity.json
@@ -2,7 +2,7 @@
     "puzzle": "4x4",
     "diagramType": "2D",
     "texts": [
-        "When you are solving a 4x4, PLL parity can significantly slow down a solve. Luckily, there are some tricks you can use to minimize the damage without learning too mamny new algorithms.",
+        "When you are solving a 4x4, PLL parity can significantly slow down a solve. Luckily, there are some tricks you can use to minimize the damage without learning too many new algorithms.",
         "Some algorithms in this set are similar to PLL algorithms you already know, except there is a parity algorithm mixed in. By doing the parity algorithm strategically, you can turn a slow PLL into a fast PLL."
     ],
     "cases": {


### PR DESCRIPTION
## What's changed
- Corrects `mamny` -> `many` in the 4x4 PLL parity copy
- Updates all source locations for this content so generated/runtime pages stay consistent

Closes #23